### PR TITLE
Fix project dropdown context and route-preserving switching

### DIFF
--- a/apps/factory-web/src/client/lib/project-routing.ts
+++ b/apps/factory-web/src/client/lib/project-routing.ts
@@ -1,0 +1,15 @@
+export function pathForProjectSelection(pathname: string, projectId: string): string {
+  const normalizedPath = pathname.trim().length > 0 ? pathname : "/";
+
+  const projectMatch = normalizedPath.match(/^\/projects\/[^/]+(\/.*)?$/);
+  if (projectMatch) {
+    const suffix = projectMatch[1] ?? "";
+    return `/projects/${projectId}${suffix}`;
+  }
+
+  if (normalizedPath.startsWith("/runs/")) {
+    return `/projects/${projectId}/runs`;
+  }
+
+  return `/projects/${projectId}`;
+}

--- a/test/web-project-routing.test.ts
+++ b/test/web-project-routing.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { pathForProjectSelection } from "../apps/factory-web/src/client/lib/project-routing";
+
+describe("project routing helpers", () => {
+  it("keeps project sub-route when switching project", () => {
+    expect(pathForProjectSelection("/projects/proj-a/secrets", "proj-b")).toBe("/projects/proj-b/secrets");
+    expect(pathForProjectSelection("/projects/proj-a/runs", "proj-b")).toBe("/projects/proj-b/runs");
+  });
+
+  it("routes run detail pages back to selected project runs", () => {
+    expect(pathForProjectSelection("/runs/run-1", "proj-b")).toBe("/projects/proj-b/runs");
+    expect(pathForProjectSelection("/runs/run-1/artifacts/art-1", "proj-b")).toBe(
+      "/projects/proj-b/runs"
+    );
+  });
+
+  it("defaults to project overview from non-project routes", () => {
+    expect(pathForProjectSelection("/", "proj-b")).toBe("/projects/proj-b");
+    expect(pathForProjectSelection("/projects", "proj-b")).toBe("/projects/proj-b");
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes the project switcher UX bug and polishes project-context behavior across route transitions.

### What changed
- Fixed project context resolution in [`AppShell`](/Users/craig.jones/projects/attractor/apps/factory-web/src/client/components/layout/app-shell.tsx):
  - On `/runs/:runId` and `/runs/:runId/artifacts/:artifactId`, the selected project now resolves from the run (`run.projectId`) instead of defaulting to the first project.
  - Sidebar project links and breadcrumbs now use the run’s owning project on run-scoped pages.
- Added project switch routing helper [`project-routing.ts`](/Users/craig.jones/projects/attractor/apps/factory-web/src/client/lib/project-routing.ts):
  - Switching projects while on `/projects/:id/<subroute>` preserves the same subroute.
  - Switching projects while on run-scoped pages routes to the selected project’s `/runs` page.
- Added regression tests in [`web-project-routing.test.ts`](/Users/craig.jones/projects/attractor/test/web-project-routing.test.ts).

## QA
### Automated
- `npm run check-types` ✅
- `npm run test` ✅ (12 files, 29 tests)
- `npm run build` ✅

### Local deploy verification (OrbStack)
- `npm run images:build:local` ✅
- `npm run k8s:deploy:local` ✅
- Verified app live at `http://192.168.139.2`

### Manual regression matrix (Chrome DevTools MCP)
1. **Bug repro baseline**
- Opened `/runs/cmm0wc14w000bxs1fk5w1v3n6`.
- Confirmed previously wrong behavior (on old build): dropdown and sidebar pointed at `global-secret-run-test` while run belongs to `attractor-self`.

2. **Run detail context resolution**
- Opened `/runs/cmm0wc14w000bxs1fk5w1v3n6` on patched build.
- Confirmed dropdown value = `attractor-self`.
- Confirmed sidebar links and breadcrumbs point to project `cmm0tdneq0000u01ntme1tnj9` (`attractor-self`).

3. **Switch project from run detail**
- From `/runs/cmm0wc14w000bxs1fk5w1v3n6`, switched dropdown to `global-secret-run-test`.
- Confirmed navigation to `/projects/cmm0vviz30001xs1fvc47vnz9/runs`.

4. **Preserve subroute on project-scoped pages**
- On `/projects/cmm0vviz30001xs1fvc47vnz9/secrets`, switched dropdown to `attractor-self`.
- Confirmed navigation to `/projects/cmm0tdneq0000u01ntme1tnj9/secrets` (subroute preserved).

5. **Artifact route behavior**
- Opened `/runs/cmm0wc14w000bxs1fk5w1v3n6/artifacts/cmm0wccap01oq2n0179dzat2t`.
- Confirmed dropdown context = `attractor-self`.
- Switched dropdown to `global-secret-run-test` and confirmed navigation to selected project’s runs page.

6. **Cross-project run verification**
- Opened `/runs/cmm0vvj2n0005xs1fx1qcnfz3` (belongs to `global-secret-run-test`).
- Confirmed dropdown/breadcrumb/sidebar all resolve to that project.

### Console/network checks
- No blocking runtime JS errors observed.
- Network requests for app APIs returned expected 200/304 responses during tested flows.
- Browser surfaced non-blocking accessibility issues (missing form `id/name`/label associations) that predate this fix and are not functionally regressive.

## Risk
- Low. Change is isolated to web shell project-context routing + deterministic helper tests.
